### PR TITLE
Fix integer data type in InfluxDB Line protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
+.idea
 .DS_Store

--- a/influxdb-client/Cargo.toml
+++ b/influxdb-client/Cargo.toml
@@ -10,13 +10,11 @@ repository = "https://github.com/Andorr/influxdb-client-rs"
 readme = "../README.md"
 include = ["src/**/**", "Cargo.toml", "../README.md"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-
 [dependencies]
 influxdb-derives = { path = "../influxdb-derives", version = "0.1.0" }
 
 reqwest = { version = "0.11.1", default-features = false }
+flate2 = "1.0.23"
 url = "2.2.2"
 
 thiserror = "1.0.24"

--- a/influxdb-client/src/models.rs
+++ b/influxdb-client/src/models.rs
@@ -1,11 +1,13 @@
+use std::fmt::Write;
+
 use crate::escape;
 use crate::traits::PointSerialize;
-use std::fmt::Write;
 
 #[derive(Debug, Clone)]
 pub enum Value {
     Str(String),
     Int(i64),
+    UInt(u64),
     Float(f64),
     Bool(bool),
 }
@@ -19,6 +21,12 @@ impl From<&str> for Value {
 impl From<f64> for Value {
     fn from(v: f64) -> Value {
         Value::Float(v)
+    }
+}
+
+impl From<u64> for Value {
+    fn from(v: u64) -> Value {
+        Value::UInt(v)
     }
 }
 
@@ -134,10 +142,13 @@ impl PointSerialize for Point {
                             "\"{}\"",
                             escape::escape_field_value_string(&s)
                         )
-                        .unwrap();
+                            .unwrap();
                     }
                     Value::Int(i) => {
                         write!(&mut builder, "{}i", i).unwrap();
+                    }
+                    Value::UInt(i) => {
+                        write!(&mut builder, "{}u", i).unwrap();
                     }
                     Value::Float(f) => {
                         write!(&mut builder, "{}", f).unwrap();

--- a/influxdb-client/src/models.rs
+++ b/influxdb-client/src/models.rs
@@ -137,7 +137,7 @@ impl PointSerialize for Point {
                         .unwrap();
                     }
                     Value::Int(i) => {
-                        write!(&mut builder, "{}", i).unwrap();
+                        write!(&mut builder, "{}i", i).unwrap();
                     }
                     Value::Float(f) => {
                         write!(&mut builder, "{}", f).unwrap();

--- a/influxdb-client/tests/test_client_write.rs
+++ b/influxdb-client/tests/test_client_write.rs
@@ -1,9 +1,13 @@
-use influxdb_client::{timestamp, Client, Point, Precision, Timestamp, TimestampOptions};
+use std::io::Write;
 
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use mockito::Matcher;
 
+use influxdb_client::{timestamp, Client, Point, Precision, Timestamp, TimestampOptions};
+
 #[test]
-fn test_client_write() {
+fn test_client_write_plain() {
     let api_key = "TEST_API_KEY";
 
     let mock = mockito::mock("POST", "/api/v2/write")
@@ -23,6 +27,48 @@ fn test_client_write() {
         .with_bucket("tradely")
         .with_org_id("168f31904923e853")
         .with_precision(Precision::MS);
+
+    let point = Point::new("test")
+        .tag("ticker", "GME")
+        .field("price", 420.69)
+        .timestamp(1613925577);
+
+    let points: Vec<Point> = vec![point];
+    let result = tokio_test::block_on(client.insert_points(&points, timestamp!(1613925577)));
+
+    assert!(result.is_ok());
+
+    mock.assert();
+}
+
+#[test]
+fn test_client_write_compressed() {
+    let api_key = "TEST_API_KEY";
+
+    let body: Vec<u8> = vec![
+        31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 1, 39, 0, 216, 255, 116, 101, 115, 116, 44, 116, 105,
+        99, 107, 101, 114, 61, 71, 77, 69, 32, 112, 114, 105, 99, 101, 61, 52, 50, 48, 46, 54, 57,
+        32, 49, 54, 49, 51, 57, 50, 53, 53, 55, 55, 179, 79, 127, 46, 39, 0, 0, 0,
+    ];
+    let mock = mockito::mock("POST", "/api/v2/write")
+        .with_status(201)
+        .match_header("content-type", "text/plain")
+        .match_header("content-encoding", "gzip")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("bucket".into(), "tradely".into()),
+            Matcher::UrlEncoded("orgID".into(), "168f31904923e853".into()),
+            Matcher::UrlEncoded("precision".into(), "ms".into()),
+        ]))
+        .match_body(body)
+        .expect(1)
+        .create();
+
+    let client = Client::new(mockito::server_url(), String::from(api_key))
+        .unwrap()
+        .with_bucket("tradely")
+        .with_org_id("168f31904923e853")
+        .with_precision(Precision::MS)
+        .with_compression(6u32);
 
     let point = Point::new("test")
         .tag("ticker", "GME")

--- a/influxdb-client/tests/test_point_serialize.rs
+++ b/influxdb-client/tests/test_point_serialize.rs
@@ -2,11 +2,12 @@ use influxdb_client::{Point, PointSerialize, Timestamp};
 
 #[test]
 fn test_point_serialize_with_timestamp_from_point() {
-    let expected = "mem,host=host1 used_percent=23.43234543 1556813561098000000";
+    let expected = "mem,host=host1 used_percent=23.43234543,mem_free=123456i 1556813561098000000";
 
     let point = Point::new("mem")
         .tag("host", "host1")
         .field("used_percent", 23.43234543)
+        .field("mem_free", 123456)
         .timestamp(1556813561098000000);
 
     let actual = point.serialize_with_timestamp(None);
@@ -16,12 +17,13 @@ fn test_point_serialize_with_timestamp_from_point() {
 
 #[test]
 fn test_point_serialize_with_timestamp() {
-    let expected = "mem,host=host1,origin=origin1 used_percent=23.43234543 420";
+    let expected = "mem,host=host1,origin=origin1 used_percent=23.43234543,mem_free=123456i 420";
 
     let point = Point::new("mem")
         .tag("host", "host1")
         .tag("origin", "origin1")
         .field("used_percent", 23.43234543)
+        .field("mem_free", 123456)
         .timestamp(1556896326);
 
     let actual = point.serialize_with_timestamp(Some(Timestamp::from(420)));
@@ -31,11 +33,12 @@ fn test_point_serialize_with_timestamp() {
 
 #[test]
 fn test_point_serialize() {
-    let expected = "mem,host=host1 used_percent=23.43234543,name=\"Julius\"";
+    let expected = "mem,host=host1 used_percent=23.43234543,mem_free=123456i,name=\"Julius\"";
 
     let point = Point::new("mem")
         .tag("host", "host1")
         .field("used_percent", 23.43234543)
+        .field("mem_free", 123456)
         .field("name", "Julius")
         .timestamp(1556896326);
 
@@ -68,7 +71,7 @@ fn test_point_serialize_only_measurement() {
 
 #[test]
 fn test_point_serialize_all_types() {
-    let expected = r#"mem,tag_string=Hello\ world\ :D float=2.345,bool=true,int=-9223372036854775806,field_string="Hello world :D\"" -9223372036854775806"#;
+    let expected = r#"mem,tag_string=Hello\ world\ :D float=2.345,bool=true,int=-9223372036854775806i,field_string="Hello world :D\"" -9223372036854775806"#;
 
     let point = Point::new("mem")
         .tag("tag_string", "Hello world :D")

--- a/influxdb-client/tests/test_point_serialize.rs
+++ b/influxdb-client/tests/test_point_serialize.rs
@@ -2,12 +2,13 @@ use influxdb_client::{Point, PointSerialize, Timestamp};
 
 #[test]
 fn test_point_serialize_with_timestamp_from_point() {
-    let expected = "mem,host=host1 used_percent=23.43234543,mem_free=123456i 1556813561098000000";
+    let expected = "mem,host=host1 used_percent=23.43234543,mem_total=123456u,mem_free=123i 1556813561098000000";
 
     let point = Point::new("mem")
         .tag("host", "host1")
-        .field("used_percent", 23.43234543)
-        .field("mem_free", 123456)
+        .field("used_percent", 23.43234543f64)
+        .field("mem_total", 123456u64)
+        .field("mem_free", 123i64)
         .timestamp(1556813561098000000);
 
     let actual = point.serialize_with_timestamp(None);
@@ -17,13 +18,14 @@ fn test_point_serialize_with_timestamp_from_point() {
 
 #[test]
 fn test_point_serialize_with_timestamp() {
-    let expected = "mem,host=host1,origin=origin1 used_percent=23.43234543,mem_free=123456i 420";
+    let expected = "mem,host=host1,origin=origin1 used_percent=23.43234543,mem_total=123456u,mem_free=123i 420";
 
     let point = Point::new("mem")
         .tag("host", "host1")
         .tag("origin", "origin1")
-        .field("used_percent", 23.43234543)
-        .field("mem_free", 123456)
+        .field("used_percent", 23.43234543f64)
+        .field("mem_total", 123456u64)
+        .field("mem_free", 123i64)
         .timestamp(1556896326);
 
     let actual = point.serialize_with_timestamp(Some(Timestamp::from(420)));
@@ -33,12 +35,13 @@ fn test_point_serialize_with_timestamp() {
 
 #[test]
 fn test_point_serialize() {
-    let expected = "mem,host=host1 used_percent=23.43234543,mem_free=123456i,name=\"Julius\"";
+    let expected = "mem,host=host1 used_percent=23.43234543,mem_total=123456u,mem_free=123i,name=\"Julius\"";
 
     let point = Point::new("mem")
         .tag("host", "host1")
-        .field("used_percent", 23.43234543)
-        .field("mem_free", 123456)
+        .field("used_percent", 23.43234543f64)
+        .field("mem_total", 123456u64)
+        .field("mem_free", 123i64)
         .field("name", "Julius")
         .timestamp(1556896326);
 
@@ -71,13 +74,14 @@ fn test_point_serialize_only_measurement() {
 
 #[test]
 fn test_point_serialize_all_types() {
-    let expected = r#"mem,tag_string=Hello\ world\ :D float=2.345,bool=true,int=-9223372036854775806i,field_string="Hello world :D\"" -9223372036854775806"#;
+    let expected = r#"mem,tag_string=Hello\ world\ :D float=2.345,bool=true,uint=18446744073709551615u,int=-9223372036854775806i,field_string="Hello world :D\"" -9223372036854775806"#;
 
     let point = Point::new("mem")
         .tag("tag_string", "Hello world :D")
         .field("float", 2.345)
         .field("bool", true)
-        .field("int", -9223372036854775806)
+        .field("uint", 18446744073709551615u64)
+        .field("int", -9223372036854775806i64)
         .field("field_string", "Hello world :D\"")
         .timestamp(-9223372036854775806);
 


### PR DESCRIPTION
Closes #15

This change adds the "i" suffix to all field values with integer data type accordingly with InfluxDB Line Protocol

See for details:
* https://docs.influxdata.com/influxdb/v2.2/reference/syntax/line-protocol/#integer